### PR TITLE
Contributed to git-in-gear-2 via CSI VLearn task

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@
 3. [Vanshika Beria](http://github.com/galaxy-milky)
 4. [Pavan Kumar K](https;//github.com/Think-big2917)
 5. [Eshwar Chandra](https://github.com/EshwarYadav29)
+
+
+CSI VLearn Task Contributors
+
+1. \[Thirsa Tharuni](https://github.com/Abh1goldy)- CSI VLearn Member


### PR DESCRIPTION
As part of the CSI VLearn Git contribution task, I’ve added my name and GitHub profile link to the README.md under the CSI VLearn contributors section.